### PR TITLE
Use radians function rather than magic constants

### DIFF
--- a/display-transforms/nuke/CAM_DRT_v044.blink
+++ b/display-transforms/nuke/CAM_DRT_v044.blink
@@ -1458,7 +1458,8 @@ float3 uncompress_bjorn(float3 xyz)
     if (cc_et == 0)
     {
       // NOTE: custom scaler 0.275 instead of 0.25 in CAM16
-      e_t = 0.275f * (cos(2.0f + h * PI / 180.0f) + 3.8f);
+      float hr = radians(h);
+      e_t = 0.275f * (cos(2.0f + hr) + 3.8f);
     }
     // Hellwig2022
     // CAM16 vs Hellwig2022: https://onlinelibrary.wiley.com/cms/asset/60788dfc-6bae-4949-bf8d-bd8c3467aef8/col22792-fig-0005-m.jpg


### PR DESCRIPTION
Use radians function rather than magic constants

Signed-off-by: Kevin Wheatley <kevin.wheatley@framstore.com>
