### PR TITLE
Correct powerP exponent to 1.0

### DIFF
--- a/display-transforms/nuke/CAM_DRT_v060.nk
+++ b/display-transforms/nuke/CAM_DRT_v060.nk
@@ -92,7 +92,7 @@ Group {
  addUserKnob {7 focusgain l "focus gain" -STARTLINE}
  focusgain 0.55
  addUserKnob {19 compression_params l compression t "the threshold, min limit, max limit, and power parameters for the PowerP compression function\n\nvalues below the threshold will not be compressed and values at the limit will be compressed towards the gamut boundary while the power values defines the shape of the curve"}
- compression_params {0.75 1.1 1.3 1.2}
+ compression_params {0.75 1.1 1.3 1.0}
  addUserKnob {6 compression_params_panelDropped l "panel dropped state" -STARTLINE +HIDDEN}
  addUserKnob {7 smooth_cusps l "smooth cusps" t "the amount by how much to smooth the edges and corners of the limiting gamut cube, except the black & white corners."}
  smooth_cusps 0.12


### PR DESCRIPTION
The powerP exponent in the CTL has been set to 1.0, making the curve identical to Reinhard (and therefore potentially simplifiable). The [v60 .nk](https://github.com/alexfry/output-transforms-dev/blob/b02bd7714dc4a1871ecabb846f3a099d25c46e39/display-transforms/nuke/CAM_DRT_v060.nk#L95) file still has it set to 1.2.

This PR makes the Blink match the CTL, with differences only in the fifth decimal place for all but the most extreme input values. And even then the largest difference I could find was 0.0015.